### PR TITLE
Align inputs with docs and fix issue with wrong id sent when scrobbling shows

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Tautulli > Settings > Notification Agents > New Script > Script Arguments:
   
   Select: 
         Playback Start
-        Arguments:  ---action startScrobble --userId {user_id}  --progress {progress_percent} <movie>--tmdbId {themoviedb_id}</movie> <episode>--tvdbId {thetvdb_id} --season {season_num} --episode {episode_num}</episode>
+        Arguments: --action startScrobble --userId {user_id}  --progress {progress_percent} <movie>--tmdbId {themoviedb_id}</movie> <episode>--tvdbId {thetvdb_id} --season {season_num} --episode {episode_num}</episode>
         
         Playback Stop
         Arguments: --action pauseScrobble --userId {user_id}  --progress {progress_percent} <movie>--tmdbId {themoviedb_id}</movie> <episode>--tvdbId {thetvdb_id} --season {season_num} --episode {episode_num}</episode>

--- a/trakt_syncer.py
+++ b/trakt_syncer.py
@@ -89,7 +89,7 @@ class Application(object):
         self.action = action
         self.traktClient = TraktClient(config)
 
-        if season is not None and episode is not None and progress is not None:
+        if tvdb_id is not None and season is not None and episode is not None and progress is not None:
             self.show = TraktShow(tvdb_id)
             self.episode = TraktEpisode(season, episode, progress, self.show)
         elif tmdbId is not None and progress is not None:
@@ -226,13 +226,16 @@ if __name__ == "__main__":
                         help='Progress inside the episode.')
 
     parser.add_argument('--tmdbId', type=str,
-                        help='TMDB ID for a movie or a show (for shows only, needs to be combined with season and episode parameters).')
+                        help='TMDB ID for a movie')
+    
+    parser.add_argument('--tvdbId', type=str,
+                        help='TVDB ID for a show, needs to be combined with season and episode parameters.')
 
     opts = parser.parse_args()
 
     app = Application(opts.userId,
                       opts.action,
-                      opts.tmdbId if hasattr(opts, 'tmdbId') and hasattr(opts, "episode") else None,
+                      opts.tvdbId if hasattr(opts, 'tvdbId') else None,
                       opts.season if hasattr(opts, 'season') else None,
                       opts.episode if hasattr(opts, 'episode') else None,
                       opts.progress if hasattr(opts, 'progress') else None,

--- a/utils/trakt_client.py
+++ b/utils/trakt_client.py
@@ -164,7 +164,7 @@ class TraktClient:
     def stopScrobble(self, episode: TraktEpisode = None, show: TraktShow = None, movie: TraktMovie = None):
         if show is not None:
             if episode is not None:
-                print("Send Stop Scrobble %s - S%sE%s to Trakt.tv" % (show.tmdb_id, episode.season_num, episode.episode_num))
+                print("Send Stop Scrobble %s - S%sE%s to Trakt.tv" % (show.tvdb_id, episode.season_num, episode.episode_num))
                 #TODO: call the trakt api with the access token
                 # Trakt['scrobble'].stop(
                 #     show=show.generateTraktDict(),

--- a/utils/trakt_client.py
+++ b/utils/trakt_client.py
@@ -60,7 +60,7 @@ class TraktClient:
     def startScrobble(self, episode: TraktEpisode = None, show: TraktShow = None, movie: TraktMovie = None):
         if show is not None:
             if episode is not None:
-                print("Send Start Scrobble %s - S%sE%s to Trakt.tv" % (show.tmdb_id, episode.season_num, episode.episode_num))
+                print("Send Start Scrobble %s - S%sE%s to Trakt.tv" % (show.tvdb_id, episode.season_num, episode.episode_num))
                 status_code, data = self.traktApiClient.post(
                     TRAKT_API_URL + "scrobble/start",
                     {
@@ -110,7 +110,7 @@ class TraktClient:
     def pauseScrobble(self, episode: TraktEpisode = None, show: TraktShow = None, movie: TraktMovie = None):
         if show is not None:
             if episode is not None:
-                print("Send Pause Scrobble %s - S%sE%s to Trakt.tv" % (show.tmdb_id, episode.season_num, episode.episode_num))
+                print("Send Pause Scrobble %s - S%sE%s to Trakt.tv" % (show.tvdb_id, episode.season_num, episode.episode_num))
                 #TODO: call the trakt api with the access token
                 # Trakt['scrobble'].pause(
                 #     show=show.generateTraktDict(),

--- a/utils/trakt_episode.py
+++ b/utils/trakt_episode.py
@@ -18,6 +18,6 @@ class TraktEpisode(TraktItem):
     def generateShowTraktDict(self) -> dict:
         return {
             'ids': {
-                'tmdb': self.show.tmdb_id,
+                'tvdb': self.show.tvdb_id,
             }
         }

--- a/utils/trakt_show.py
+++ b/utils/trakt_show.py
@@ -3,11 +3,11 @@ from utils.trakt_item import TraktItem
 
 class TraktShow(TraktItem):
     def __init__(self, m: int):
-        self.tmdb_id = m
+        self.tvdb_id = m
 
     def generateEpisodeTraktDict(self) -> dict:
         return {
             'ids': {
-                'tvdb': self.tmdb_id,
+                'tvdb': self.tvdb_id,
             }
         }


### PR DESCRIPTION
- Docs use the parameter tvdbId but the required input was tmdbId. So the input was changed to tvdbId when scrobbling shows. 
- Was getting 404 when attempting to scrobble shows as they were using tmdb id instead of tvdb id. 